### PR TITLE
Remove clojars deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,6 @@ This will produce an updated `pom.xml` file with synchronized dependencies insid
 directory inside `target/classes` and the JAR in `target`. You can update the version (and SCM tag)
 information in generated `pom.xml` by updating `build.clj`.
 
-Install it locally (requires the `ci` task be run first):
-
-    $ clojure -T:build install
-
-Deploy it to Clojars -- needs `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` environment
-variables (requires the `ci` task be run first):
-
-    $ clojure -T:build deploy
-
 ## License
 
 Copyright © 2023 Gabriel Luque Di Donna

--- a/build.clj
+++ b/build.clj
@@ -1,7 +1,6 @@
 (ns build
   (:refer-clojure :exclude [test])
-  (:require [clojure.tools.build.api :as b]
-            [deps-deploy.deps-deploy :as dd]))
+  (:require [clojure.tools.build.api :as b]))
 
 (def lib 'io.github.galuque/datomic-jmx-metrics)
 (def version (format "0.1.%s" (b/git-count-revs nil)))
@@ -37,15 +36,4 @@
     (b/copy-dir {:src-dirs ["resources" "src"] :target-dir class-dir})
     (println "\nBuilding JAR...")
     (b/jar opts))
-  opts)
-
-(defn install "Install the JAR locally." [opts]
-  (let [opts (jar-opts opts)]
-    (b/install opts))
-  opts)
-
-(defn deploy "Deploy the JAR to Clojars." [opts]
-  (let [{:keys [jar-file] :as opts} (jar-opts opts)]
-    (dd/deploy {:installer :remote :artifact (b/resolve-path jar-file)
-                :pom-file (b/pom-path (select-keys opts [:lib :class-dir]))}))
   opts)

--- a/deps.edn
+++ b/deps.edn
@@ -12,6 +12,5 @@
 
   :build
   {:deps {io.github.clojure/tools.build {:git/tag "v0.9.2"
-                                         :git/sha "fe6b140"}
-          slipset/deps-deploy           {:mvn/version "0.2.0"}}
+                                         :git/sha "fe6b140"}}
    :ns-default build}}}

--- a/src/io/github/galuque/datomic/jmx/metrics.clj
+++ b/src/io/github/galuque/datomic/jmx/metrics.clj
@@ -1,12 +1,12 @@
-;   Copyright (c) Gabriel Luque Di Donna. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   MIT License (https://opensource.org/license/mit/)
-;   which can be found in the file LICENSE at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;Copyright (c) Gabriel Luque Di Donna. All rights reserved.
+;The use and distribution terms for this software are covered by the
+;MIT License (https://opensource.org/license/mit/)
+;which can be found in the file LICENSE at the root of this distribution.
+;By using this software in any fashion, you are agreeing to be bound by
+;the terms of this license.
+;You must not remove this notice, or any other, from this software.
 (ns io.github.galuque.datomic.jmx.metrics
-  "A Clojure library that provodes a function handler
+  "A Clojure library that providdes a function handler
    for writing Datomic metrics to JMX"
   (:require [clojure.java.jmx :as jmx]))
 
@@ -16,53 +16,53 @@
 
 (def ^{:doc "External Datomic metric names as defined in 
              https://docs.datomic.com/pro/operation/monitoring.html#available-cloudwatch-metrics"
-       :private true} names #{"AlarmIndexingJobFailed"
-                              "AlarmBackPressure"
-                              "AlarmUnhandledException"
-                              "AvailableMB"
-                              "ClusterCreateFS"
-                              "CreateEntireIndexMsec"
-                              "CreateFulltextIndexMsec"
-                              "Datoms"
-                              "DbAddFulltextMsec"
-                              "FulltextSegments"
-                              "GarbageSegments"
-                              "HeartbeatMsec"
-                              "HeartMonitorMsec"
-                              "IndexDatoms"
-                              "IndexSegments"
-                              "IndexWrites"
-                              "IndexWriteMsec"
-                              "LogIngestBytes"
-                              "LogIngestMsec"
-                              "LogWriteMsec"
-                              "Memcache"
-                              "MemcachedGetFailedMsec"
-                              "MemcachedGetSucceededMsec"
-                              "MemcachedGetMissedMsec"
-                              "MemcachedPutFailedMsec"
-                              "MemcachedPutSucceededMsec"
-                              "MemcachedPutMissedMsec"
-                              "MemoryIndexFillMsec"
-                              "MemoryIndexMB"
-                              "MetricsReport"
-                              "ObjectCache"
-                              "ObjectCacheCount"
-                              "ReaderCachePut"
-                              "RemotePeers" 
-                              "StorageGetBytes"
-                              "StorageGetMsec"
-                              "StoragePutBytes"
-                              "StoragePutMsec"
-                              "StorageBackoff"
-                              "TransactionBatch"
-                              "TransactionBytes"
-                              "TransactionDatoms"
-                              "TransactionMsec" 
-                              "ValcachePutFailedMsec"
-                              "ValcachePutMsec"
-                              "WriterCachePut"
-                              "WriterMemcached"})
+       :private true} names #{:AlarmIndexingJobFailed
+                              :AlarmBackPressure
+                              :AlarmUnhandledException
+                              :AvailableMB
+                              :ClusterCreateFS
+                              :CreateEntireIndexMsec
+                              :CreateFulltextIndexMsec
+                              :Datoms
+                              :DbAddFulltextMsec
+                              :FulltextSegments
+                              :GarbageSegments
+                              :HeartbeatMsec
+                              :HeartMonitorMsec
+                              :IndexDatoms
+                              :IndexSegments
+                              :IndexWrites
+                              :IndexWriteMsec
+                              :LogIngestBytes
+                              :LogIngestMsec
+                              :LogWriteMsec
+                              :Memcache
+                              :MemcachedGetFailedMsec
+                              :MemcachedGetSucceededMsec
+                              :MemcachedGetMissedMsec
+                              :MemcachedPutFailedMsec
+                              :MemcachedPutSucceededMsec
+                              :MemcachedPutMissedMsec
+                              :MemoryIndexFillMsec
+                              :MemoryIndexMB
+                              :MetricsReport
+                              :ObjectCache
+                              :ObjectCacheCount
+                              :ReaderCachePut
+                              :RemotePeers
+                              :StorageGetBytes
+                              :StorageGetMsec
+                              :StoragePutBytes
+                              :StoragePutMsec
+                              :StorageBackoff
+                              :TransactionBatch
+                              :TransactionBytes
+                              :TransactionDatoms
+                              :TransactionMsec
+                              :ValcachePutFailedMsec
+                              :ValcachePutMsec
+                              :WriterCachePut
+                              :WriterMemcached})
 
 (defn- ->mbean-name
   "Converts a metric name (of the ones defined 
@@ -71,11 +71,11 @@
    
    Example:
    
-   (->mbean-name \"AvailableMB\")
+   (->mbean-name :AvailableMB)
    => \"io.github.galuque.datomic.jmx.metrics:name=AvailableMB\"
    "
   [metric-name]
-  (str namespace-sym ":name=" metric-name))
+  (str namespace-sym ":name=" (name metric-name)))
 
 (defn- register-mbean!
   "Registers a JMX MBean for `metric-name` in the current JMX server 
@@ -120,17 +120,28 @@
   (register-all! names)
   (fn [metric-data]
     (let [metric-names (keys metric-data)]
-      (doseq [metric-keyword metric-names]
-        (let [data        (get metric-data metric-keyword)
-              metric-name (name metric-keyword)
-              mbname      (->mbean-name metric-name)]
-          (when (contains? names metric-name)
+      (doseq [metric metric-names]
+        (let [data   (get metric-data metric) 
+              mbname (->mbean-name metric)]
+          (if (contains? names metric)
             (cond
               (number? data)
               (write! mbname data)
 
               (map? data)
               (doseq [k (keys data)]
-                (write! mbname k data)))))))))
+                (write! mbname k data))
 
+              :else
+              (do
+                (println "Metric is neither a map nor a numerical value")
+                (println "Metric: " metric)
+                (println "Data: " data)))
+            ;else
+            (do
+              (println "Unknown metric")
+              (println "Metric: " metric)
+              (println "Data: " data))))))))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (def callback (make-callback))

--- a/test/io/github/galuque/datomic/jmx/metrics_test.clj
+++ b/test/io/github/galuque/datomic/jmx/metrics_test.clj
@@ -1,10 +1,10 @@
-;   Copyright (c) Gabriel Luque Di Donna. All rights reserved.
-;   The use and distribution terms for this software are covered by the
-;   MIT License (https://opensource.org/license/mit/)
-;   which can be found in the file LICENSE at the root of this distribution.
-;   By using this software in any fashion, you are agreeing to be bound by
-;   the terms of this license.
-;   You must not remove this notice, or any other, from this software.
+;Copyright (c) Gabriel Luque Di Donna. All rights reserved.
+;The use and distribution terms for this software are covered by the
+;MIT License (https://opensource.org/license/mit/)
+;which can be found in the file LICENSE at the root of this distribution.
+;By using this software in any fashion, you are agreeing to be bound by
+;the terms of this license.
+;You must not remove this notice, or any other, from this software.
 (ns io.github.galuque.datomic.jmx.metrics-test
   (:require [clojure.test :refer [deftest is testing]]
             [io.github.galuque.datomic.jmx.metrics :as metrics]
@@ -19,7 +19,7 @@
 (deftest io.github.galuque.datomic.jmx.metrics-test
   (testing "MBean name conversion"
     (is (= "io.github.galuque.datomic.jmx.metrics:name=Alarm"
-           (#'metrics/->mbean-name "Alarm"))))
+           (#'metrics/->mbean-name :Alarm))))
 
   (testing "Mbean registration"
     (unregister-all!)
@@ -31,11 +31,10 @@
 
   (testing "Mbean value writing"
     (unregister-all!)
-    (let [metric-keyword :AvailableMB
-          metric-name    (name metric-keyword)
-          mbname         (#'metrics/->mbean-name metric-name)]
+    (let [metric :AvailableMB
+          mbname (#'metrics/->mbean-name metric)]
 
-      (#'metrics/register-mbean! metric-name)
+      (#'metrics/register-mbean! metric)
 
       (#'metrics/write! mbname 889.1)
       (is (= 889.1 (jmx/read mbname :value)))
@@ -45,15 +44,14 @@
 
   (testing "Mbean map writing"
     (unregister-all!)
-    (let [metric-keyword :HeartMonitorMsec
-          metric-data   {:lo 5000
-                         :hi 5001
-                         :sum 60002
-                         :count 12}
-          metric-name    (name metric-keyword)
-          mbname         (#'metrics/->mbean-name metric-name)]
+    (let [metric      :HeartMonitorMsec
+          metric-data {:lo 5000
+                       :hi 5001
+                       :sum 60002
+                       :count 12}
+          mbname      (#'metrics/->mbean-name metric)]
 
-      (#'metrics/register-mbean! metric-name)
+      (#'metrics/register-mbean! metric)
 
       (#'metrics/write! mbname :lo metric-data)
       (#'metrics/write! mbname :hi metric-data)
@@ -68,18 +66,17 @@
   (testing "Callback function"
     (unregister-all!)
     (let [callback    (#'metrics/make-callback)
-          metric-data {:RemotePeers {:lo 1, :hi 1, :sum 1, :count 1},
-                       :MetricsReport {:lo 1, :hi 1, :sum 1, :count 1},
-                       :MemoryIndexMB {:lo 0, :hi 0, :sum 0, :count 1},
-                       :HeartbeatMsec {:lo 5000, :hi 5001, :sum 60002, :count 12},
-                       :AvailableMB 818.0,
+          metric-data {:RemotePeers      {:lo 1, :hi 1, :sum 1, :count 1},
+                       :MetricsReport    {:lo 1, :hi 1, :sum 1, :count 1},
+                       :MemoryIndexMB    {:lo 0, :hi 0, :sum 0, :count 1},
+                       :HeartbeatMsec    {:lo 5000, :hi 5001, :sum 60002, :count 12},
+                       :AvailableMB      818.0,
                        :ObjectCacheCount 20}]
       (callback metric-data)
-      (doseq [metric-keyword (keys metric-data)]
-        (let [metric-name (name metric-keyword)
-              data        (get metric-data metric-keyword)
-              mbname      (#'metrics/->mbean-name metric-name)]
-          (when (contains? @#'metrics/names metric-name)
+      (doseq [metric (keys metric-data)]
+        (let [data   (get metric-data metric)
+              mbname (#'metrics/->mbean-name metric)]
+          (when (contains? @#'metrics/names metric)
             (cond
               (number? data)
               (is (= data (jmx/read mbname :value)))


### PR DESCRIPTION
Remove deps deploy dependency a related code, as it not needed.

Since the library is intended to be used in a datomic distribution it doesn't make sense to publish it as a library

The only thing needed is the jar artifact